### PR TITLE
Add Blazor WebAssembly app and GitHub Actions deployment workflow

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -1,0 +1,50 @@
+name: Deploy HealthNerd WASM
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/HealthNerd.Wasm/**'
+      - '.github/workflows/deploy-wasm.yml'
+  workflow_dispatch:  # allow manual trigger from GitHub Actions UI
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout HealthNerd
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Publish Blazor WASM
+        run: dotnet publish src/HealthNerd.Wasm/HealthNerd.Wasm.csproj -c Release -o ./publish
+
+      - name: Checkout htmltools
+        uses: actions/checkout@v4
+        with:
+          repository: jonfuller/htmltools
+          token: ${{ secrets.HTMLTOOLS_DEPLOY_TOKEN }}
+          path: htmltools
+
+      - name: Copy WASM output to htmltools/healthnerd
+        run: |
+          rm -rf htmltools/healthnerd
+          mkdir -p htmltools/healthnerd
+          cp -r ./publish/wwwroot/. htmltools/healthnerd/
+          # Ensure Jekyll ignores _framework/ files
+          touch htmltools/.nojekyll
+
+      - name: Commit and push to htmltools
+        run: |
+          cd htmltools
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add -A
+          git diff --staged --quiet && echo "No changes to deploy" && exit 0
+          git commit -m "Deploy HealthNerd WASM from HealthNerd@${{ github.sha }}"
+          git push

--- a/src/HealthNerd.Wasm/App.razor
+++ b/src/HealthNerd.Wasm/App.razor
@@ -1,0 +1,8 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+    </Found>
+    <NotFound>
+        <p>Page not found.</p>
+    </NotFound>
+</Router>

--- a/src/HealthNerd.Wasm/HealthNerd.Wasm.csproj
+++ b/src/HealthNerd.Wasm/HealthNerd.Wasm.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Trimming disabled: HealthKitData.Core and EPPlus use XML reflection -->
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+    <PackageReference Include="HealthKitData.Core" Version="0.4.0" />
+    <!-- EPPlus 6+ required: avoids System.Drawing dependency not available in WASM -->
+    <PackageReference Include="EPPlus" Version="6.2.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NodaTime" Version="3.1.0" />
+    <PackageReference Include="Disposing" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/HealthNerd.Wasm/Models/WebSettings.cs
+++ b/src/HealthNerd.Wasm/Models/WebSettings.cs
@@ -1,0 +1,17 @@
+namespace HealthNerd.Wasm.Models;
+
+public class WebSettings
+{
+    public string DistanceUnit { get; set; } = "Mile";
+    public string MassUnit { get; set; } = "Pound";
+    public string EnergyUnit { get; set; } = "Calorie";
+    public string DurationUnit { get; set; } = "Minute";
+    public int NumberOfMonthlySummaries { get; set; } = 3;
+    public DateTime SinceDate { get; set; } = new DateTime(2020, 1, 1);
+    public bool OmitEmptyColumnsOnMonthlySummary { get; set; } = false;
+    public bool OmitEmptyColumnsOnOverallSummary { get; set; } = false;
+    public bool OmitEmptySheets { get; set; } = false;
+    public string CustomSheetsPlacement { get; set; } = "AfterSummary";
+    public bool UseConstantNameForMostRecentMonthlySummarySheet { get; set; } = true;
+    public bool UseConstantNameForPreviousMonthlySummarySheet { get; set; } = true;
+}

--- a/src/HealthNerd.Wasm/Pages/Home.razor
+++ b/src/HealthNerd.Wasm/Pages/Home.razor
@@ -224,8 +224,9 @@
             SetStatus("Generating Excel…", "");
             StateHasChanged();
 
-            var currentSettings = _settings; // capture for background thread
-            var excelBytes = await Task.Run(() => BuildExcel(exportBytes, customBytes, currentSettings, tzName));
+            var currentSettings = _settings;
+            // NOTE: In Blazor WebAssembly this still runs on the UI thread; large exports may temporarily freeze the UI.
+            var excelBytes = BuildExcel(exportBytes, customBytes, currentSettings, tzName);
 
             SetStatus("Downloading…", "");
             StateHasChanged();

--- a/src/HealthNerd.Wasm/Pages/Home.razor
+++ b/src/HealthNerd.Wasm/Pages/Home.razor
@@ -1,0 +1,308 @@
+@page "/"
+@using System.IO
+@using System.IO.Compression
+@using System.Linq
+@using HealthKitData.Core.DataExport
+@using HealthKitData.Core.Excel
+@using HealthKitData.Core.Excel.Settings
+@using NodaTime
+@using OfficeOpenXml
+@inject IJSRuntime JS
+@inject LocalStorageService Storage
+
+<div class="app-container">
+    <header>
+        <h1>HealthNerd</h1>
+        <p>Export Apple Health data to Excel</p>
+    </header>
+
+    <!-- ───── FILES ───── -->
+    <div class="card">
+        <h2>Files</h2>
+
+        <div class="file-row">
+            <label>Apple Health Export (.zip)</label>
+            <InputFile OnChange="OnExportFileChanged" accept=".zip" />
+            @if (_exportFileName is not null)
+            {
+                <span class="file-name">✓ @_exportFileName</span>
+            }
+        </div>
+
+        <div class="file-row">
+            <label>Custom Sheets (.xlsx) <span class="hint">— optional, sheets named "custom…" are included</span></label>
+            <InputFile OnChange="OnCustomSheetsChanged" accept=".xlsx" />
+            @if (_customSheetsFileName is not null)
+            {
+                <span class="file-name">✓ @_customSheetsFileName</span>
+            }
+        </div>
+    </div>
+
+    <!-- ───── SETTINGS ───── -->
+    <div class="card">
+        <h2>
+            Settings
+            <button class="btn-ghost" @onclick="ResetSettings">Reset to defaults</button>
+        </h2>
+
+        <div class="settings-grid">
+            <label>Distance unit</label>
+            <select @bind="_settings.DistanceUnit" @bind:after="SaveSettings">
+                <option value="Mile">Mile</option>
+                <option value="Meter">Meter</option>
+            </select>
+
+            <label>Weight unit</label>
+            <select @bind="_settings.MassUnit" @bind:after="SaveSettings">
+                <option value="Pound">Pound</option>
+                <option value="Kilogram">Kilogram</option>
+            </select>
+
+            <label>Energy unit</label>
+            <select @bind="_settings.EnergyUnit" @bind:after="SaveSettings">
+                <option value="Calorie">Calorie</option>
+                <option value="Kilocalorie">Kilocalorie</option>
+            </select>
+
+            <label>Duration unit</label>
+            <select @bind="_settings.DurationUnit" @bind:after="SaveSettings">
+                <option value="Minute">Minute</option>
+                <option value="Hour">Hour</option>
+            </select>
+
+            <label>Monthly summaries</label>
+            <input type="number" min="1" max="24"
+                   @bind="_settings.NumberOfMonthlySummaries"
+                   @bind:after="SaveSettings" />
+
+            <label>Data since</label>
+            <input type="date"
+                   @bind="_settings.SinceDate"
+                   @bind:after="SaveSettings" />
+        </div>
+
+        <hr class="settings-divider" />
+
+        <div class="settings-checks">
+            <label>
+                <input type="checkbox"
+                       @bind="_settings.OmitEmptyColumnsOnMonthlySummary"
+                       @bind:after="SaveSettings" />
+                Omit empty columns on monthly summary
+            </label>
+            <label>
+                <input type="checkbox"
+                       @bind="_settings.OmitEmptyColumnsOnOverallSummary"
+                       @bind:after="SaveSettings" />
+                Omit empty columns on overall summary
+            </label>
+            <label>
+                <input type="checkbox"
+                       @bind="_settings.OmitEmptySheets"
+                       @bind:after="SaveSettings" />
+                Omit empty sheets
+            </label>
+        </div>
+
+        <hr class="settings-divider" />
+
+        <div class="settings-row">
+            <label>Custom sheets placement</label>
+            <select @bind="_settings.CustomSheetsPlacement" @bind:after="SaveSettings">
+                <option value="BeforeSummary">Before summary</option>
+                <option value="AfterSummary">After summary</option>
+            </select>
+        </div>
+
+        <div class="settings-checks">
+            <label>
+                <input type="checkbox"
+                       @bind="_settings.UseConstantNameForMostRecentMonthlySummarySheet"
+                       @bind:after="SaveSettings" />
+                Use constant sheet name for most recent month
+            </label>
+            <label>
+                <input type="checkbox"
+                       @bind="_settings.UseConstantNameForPreviousMonthlySummarySheet"
+                       @bind:after="SaveSettings" />
+                Use constant sheet name for previous month
+            </label>
+        </div>
+    </div>
+
+    <!-- ───── GENERATE ───── -->
+    <div class="card">
+        <div class="generate-section">
+            <button class="btn-primary"
+                    @onclick="GenerateExcel"
+                    disabled="@(_generating || _exportFile is null)">
+                @(_generating ? "Generating…" : "Generate Excel")
+            </button>
+
+            @if (_statusMessage is not null)
+            {
+                <span class="status @_statusClass">@_statusMessage</span>
+            }
+        </div>
+
+        @if (_exportFile is null)
+        {
+            <p class="hint" style="margin-top:.5rem">Select an Apple Health export ZIP above to get started.</p>
+        }
+    </div>
+</div>
+
+@code {
+    private WebSettings _settings = new();
+    private IBrowserFile? _exportFile;
+    private string?       _exportFileName;
+    private IBrowserFile? _customSheetsFile;
+    private string?       _customSheetsFileName;
+    private bool   _generating;
+    private string? _statusMessage;
+    private string  _statusClass = "";
+
+    protected override async Task OnInitializedAsync()
+    {
+        _settings = await Storage.LoadAsync();
+    }
+
+    private void OnExportFileChanged(InputFileChangeEventArgs e)
+    {
+        _exportFile = e.File;
+        _exportFileName = e.File.Name;
+        _statusMessage = null;
+    }
+
+    private void OnCustomSheetsChanged(InputFileChangeEventArgs e)
+    {
+        _customSheetsFile = e.File;
+        _customSheetsFileName = e.File.Name;
+    }
+
+    private Task SaveSettings() => Storage.SaveAsync(_settings);
+
+    private async Task ResetSettings()
+    {
+        _settings = new WebSettings();
+        await Storage.ClearAsync();
+    }
+
+    private async Task GenerateExcel()
+    {
+        if (_exportFile is null) return;
+
+        _generating = true;
+        SetStatus("Reading export file…", "");
+        StateHasChanged();
+
+        try
+        {
+            // Read the Apple Health export ZIP into memory
+            byte[] exportBytes;
+            using (var buf = new MemoryStream())
+            {
+                await using var stream = _exportFile.OpenReadStream(maxAllowedSize: 512L * 1024 * 1024);
+                await stream.CopyToAsync(buf);
+                exportBytes = buf.ToArray();
+            }
+
+            // Read optional custom sheets XLSX
+            byte[]? customBytes = null;
+            if (_customSheetsFile is not null)
+            {
+                using var buf = new MemoryStream();
+                await using var stream = _customSheetsFile.OpenReadStream(maxAllowedSize: 50L * 1024 * 1024);
+                await stream.CopyToAsync(buf);
+                customBytes = buf.ToArray();
+            }
+
+            // Resolve browser timezone before leaving async context
+            var tzName = await JS.InvokeAsync<string>("getBrowserTimeZone");
+
+            SetStatus("Generating Excel…", "");
+            StateHasChanged();
+
+            var currentSettings = _settings; // capture for background thread
+            var excelBytes = await Task.Run(() => BuildExcel(exportBytes, customBytes, currentSettings, tzName));
+
+            SetStatus("Downloading…", "");
+            StateHasChanged();
+
+            await JS.InvokeVoidAsync(
+                "downloadFile",
+                "health-export.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                excelBytes);
+
+            SetStatus("Done — file downloaded.", "success");
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Error: {ex.Message}", "error");
+        }
+        finally
+        {
+            _generating = false;
+        }
+    }
+
+    private void SetStatus(string message, string cssClass)
+    {
+        _statusMessage = message;
+        _statusClass   = cssClass;
+    }
+
+    // ── Core processing (runs on thread-pool via Task.Run) ──────────────────
+
+    private static byte[] BuildExcel(byte[] exportBytes, byte[]? customBytes, WebSettings ws, string tzName)
+    {
+        // Locate and parse apple_health_export/export.xml inside the ZIP
+        using var zipStream = new MemoryStream(exportBytes);
+        var loader = ZipUtilities.ReadArchive(
+                zipStream,
+                entry => entry.FullName == "apple_health_export/export.xml",
+                entry => new XmlReaderExportLoader(entry.Open()))
+           .FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "apple_health_export/export.xml not found in ZIP. " +
+                "Make sure you upload the export.zip produced by the Health app.");
+
+        // Filter records by since-date.
+        // Record.Start is assumed to be NodaTime.LocalDate (verify at compile time).
+        // If HealthKitData.Core uses a different type (e.g. Instant), adjust the
+        // comparison accordingly.
+        var sinceDate = LocalDate.FromDateTime(ws.SinceDate);
+        var records  = loader.Records .Where(r => r.Start >= sinceDate).ToList();
+        var workouts = loader.Workouts.Where(w => w.Start >= sinceDate).ToList();
+
+        // Load custom sheets (sheets whose names begin with "custom")
+        ExcelPackage? customPackage = null;
+        IEnumerable<ExcelWorksheet> customSheets = Enumerable.Empty<ExcelWorksheet>();
+        if (customBytes is not null)
+        {
+            customPackage = new ExcelPackage(new MemoryStream(customBytes));
+            customSheets = customPackage.Workbook.Worksheets
+               .Where(w => w.Name.StartsWith("custom", StringComparison.CurrentCultureIgnoreCase))
+               .ToList();
+        }
+
+        // Resolve timezone (falls back to UTC if name not found in TZDB)
+        DateTimeZone tz;
+        try { tz = DateTimeZoneProviders.Tzdb[tzName]; }
+        catch { tz = DateTimeZone.Utc; }
+
+        using var excelFile = new ExcelPackage();
+        try
+        {
+            var settings = SettingsMapper.ToExcelSettings(ws);
+            ExcelReport.BuildReport(records, workouts, excelFile.Workbook, settings, tz, customSheets);
+            return excelFile.GetAsByteArray();
+        }
+        finally
+        {
+            customPackage?.Dispose();
+        }
+    }
+}

--- a/src/HealthNerd.Wasm/Program.cs
+++ b/src/HealthNerd.Wasm/Program.cs
@@ -1,0 +1,17 @@
+using System.Text;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using OfficeOpenXml;
+using HealthNerd.Wasm.Services;
+
+// Required for XML parsing of Apple Health export
+Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+// EPPlus non-commercial license (same as CLI project)
+ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<HealthNerd.Wasm.App>("#app");
+
+builder.Services.AddScoped<LocalStorageService>();
+
+await builder.Build().RunAsync();

--- a/src/HealthNerd.Wasm/Services/LocalStorageService.cs
+++ b/src/HealthNerd.Wasm/Services/LocalStorageService.cs
@@ -1,0 +1,28 @@
+using Microsoft.JSInterop;
+using Newtonsoft.Json;
+using HealthNerd.Wasm.Models;
+
+namespace HealthNerd.Wasm.Services;
+
+public class LocalStorageService(IJSRuntime js)
+{
+    private const string Key = "healthnerd_settings";
+
+    public async Task<WebSettings> LoadAsync()
+    {
+        var json = await js.InvokeAsync<string?>("localStorage.getItem", Key);
+        if (json is null) return new WebSettings();
+        return JsonConvert.DeserializeObject<WebSettings>(json) ?? new WebSettings();
+    }
+
+    public async Task SaveAsync(WebSettings settings)
+    {
+        var json = JsonConvert.SerializeObject(settings);
+        await js.InvokeVoidAsync("localStorage.setItem", Key, json);
+    }
+
+    public async Task ClearAsync()
+    {
+        await js.InvokeVoidAsync("localStorage.removeItem", Key);
+    }
+}

--- a/src/HealthNerd.Wasm/Services/SettingsMapper.cs
+++ b/src/HealthNerd.Wasm/Services/SettingsMapper.cs
@@ -1,0 +1,37 @@
+using HealthKitData.Core.Excel.Settings;
+using HealthNerd.Wasm.Models;
+using UnitsNet.Units;
+
+namespace HealthNerd.Wasm.Services;
+
+/// <summary>
+/// Converts a <see cref="WebSettings"/> POCO to the
+/// <see cref="Settings"/> object expected by HealthKitData.Core's ExcelReport.
+/// Property names and enum values mirror those in src/HealthNerd/Services/Output.cs.
+/// </summary>
+public static class SettingsMapper
+{
+    public static Settings ToExcelSettings(WebSettings ws)
+    {
+        return new Settings
+        {
+            DistanceUnit = ws.DistanceUnit == "Mile" ? LengthUnit.Mile : LengthUnit.Meter,
+            WeightUnit   = ws.MassUnit == "Pound"   ? MassUnit.Pound   : MassUnit.Kilogram,
+            EnergyUnit   = ws.EnergyUnit == "Calorie"  ? EnergyUnit.Calorie  : EnergyUnit.Kilocalorie,
+            DurationUnit = ws.DurationUnit == "Minute" ? DurationUnit.Minute : DurationUnit.Hour,
+
+            NumberOfMonthlySummaries = ws.NumberOfMonthlySummaries,
+
+            OmitEmptyColumnsOnMonthlySummary = ws.OmitEmptyColumnsOnMonthlySummary,
+            OmitEmptyColumnsOnOverallSummary = ws.OmitEmptyColumnsOnOverallSummary,
+            OmitEmptySheets                  = ws.OmitEmptySheets,
+
+            CustomSheetsPlacement = ws.CustomSheetsPlacement == "BeforeSummary"
+                ? CustomSheetsPlacement.BeforeSummary
+                : CustomSheetsPlacement.AfterSummary,
+
+            UseConstantNameForMostRecentMonthlySummarySheet = ws.UseConstantNameForMostRecentMonthlySummarySheet,
+            UseConstantNameForPreviousMonthlySummarySheet   = ws.UseConstantNameForPreviousMonthlySummarySheet,
+        };
+    }
+}

--- a/src/HealthNerd.Wasm/_Imports.razor
+++ b/src/HealthNerd.Wasm/_Imports.razor
@@ -1,0 +1,10 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using HealthNerd.Wasm
+@using HealthNerd.Wasm.Models
+@using HealthNerd.Wasm.Services

--- a/src/HealthNerd.Wasm/wwwroot/css/app.css
+++ b/src/HealthNerd.Wasm/wwwroot/css/app.css
@@ -1,0 +1,236 @@
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+:root {
+    --color-bg: #f8f9fa;
+    --color-surface: #ffffff;
+    --color-border: #dee2e6;
+    --color-text: #212529;
+    --color-text-muted: #6c757d;
+    --color-primary: #0d6efd;
+    --color-primary-hover: #0b5ed7;
+    --color-danger: #dc3545;
+    --color-success: #198754;
+    --radius: 6px;
+    --shadow: 0 1px 3px rgba(0,0,0,.1);
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 0.95rem;
+    background: var(--color-bg);
+    color: var(--color-text);
+    margin: 0;
+    padding: 1rem;
+}
+
+.app-container {
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid var(--color-primary);
+}
+
+header h1 {
+    margin: 0;
+    font-size: 1.6rem;
+    color: var(--color-primary);
+}
+
+header p {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+}
+
+.card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.card h2 {
+    margin: 0 0 1rem 0;
+    font-size: 1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+/* File inputs */
+.file-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 1rem;
+}
+
+.file-row:last-child {
+    margin-bottom: 0;
+}
+
+.file-row label {
+    font-weight: 500;
+    font-size: 0.875rem;
+}
+
+.file-row .hint {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
+.file-name {
+    font-size: 0.8rem;
+    color: var(--color-success);
+    margin-top: 0.2rem;
+}
+
+/* Settings grid */
+.settings-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.6rem 1.5rem;
+    margin-bottom: 1rem;
+    align-items: center;
+}
+
+.settings-grid label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-align: right;
+}
+
+.settings-grid select,
+.settings-grid input[type="number"],
+.settings-grid input[type="date"] {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    font-size: 0.875rem;
+    background: var(--color-surface);
+    color: var(--color-text);
+}
+
+/* Checkboxes */
+.settings-checks {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 0.75rem;
+}
+
+.settings-checks label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    cursor: pointer;
+}
+
+/* Inline grid row for single selects below checks */
+.settings-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.settings-row label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.settings-row select {
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    font-size: 0.875rem;
+    background: var(--color-surface);
+    color: var(--color-text);
+}
+
+/* Buttons */
+button {
+    cursor: pointer;
+    border: none;
+    border-radius: var(--radius);
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.4rem 0.9rem;
+    transition: background 0.15s, opacity 0.15s;
+}
+
+.btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    padding: 0.6rem 1.5rem;
+    font-size: 1rem;
+}
+
+.btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+}
+
+.btn-primary:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    font-size: 0.8rem;
+    padding: 0.25rem 0.6rem;
+}
+
+.btn-ghost:hover {
+    background: var(--color-bg);
+}
+
+/* Status */
+.status {
+    margin-top: 0.75rem;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+}
+
+.status.error {
+    color: var(--color-danger);
+}
+
+.status.success {
+    color: var(--color-success);
+}
+
+/* Generate section */
+.generate-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+/* Divider within settings card */
+.settings-divider {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 0.75rem 0;
+}

--- a/src/HealthNerd.Wasm/wwwroot/index.html
+++ b/src/HealthNerd.Wasm/wwwroot/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>HealthNerd</title>
-    <base href="/" />
+    <base href="/healthnerd/" />
     <link rel="stylesheet" href="css/app.css" />
 </head>
 <body>

--- a/src/HealthNerd.Wasm/wwwroot/index.html
+++ b/src/HealthNerd.Wasm/wwwroot/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HealthNerd</title>
+    <base href="/" />
+    <link rel="stylesheet" href="css/app.css" />
+</head>
+<body>
+    <div id="app">
+        <p style="text-align:center;padding:2rem;font-family:sans-serif;">Loading…</p>
+    </div>
+
+    <script src="js/app.js"></script>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/src/HealthNerd.Wasm/wwwroot/js/app.js
+++ b/src/HealthNerd.Wasm/wwwroot/js/app.js
@@ -1,0 +1,19 @@
+window.downloadFile = function (filename, contentType, bytes) {
+    const blob = new Blob([new Uint8Array(bytes)], { type: contentType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+};
+
+window.getBrowserTimeZone = function () {
+    try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (e) {
+        return 'UTC';
+    }
+};

--- a/src/HealthNerd.sln
+++ b/src/HealthNerd.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthNerd.Tests", "HealthN
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HealthNerd.Cli", "HealthNerd.Cli\HealthNerd.Cli.csproj", "{DF1CC946-93A3-41C0-BD00-258E9D65D9A2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthNerd.Wasm", "HealthNerd.Wasm\HealthNerd.Wasm.csproj", "{7F748FFA-752C-49E7-98F6-C07FCC364D84}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -89,6 +91,18 @@ Global
 		{DF1CC946-93A3-41C0-BD00-258E9D65D9A2}.Release|iPhone.Build.0 = Release|Any CPU
 		{DF1CC946-93A3-41C0-BD00-258E9D65D9A2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{DF1CC946-93A3-41C0-BD00-258E9D65D9A2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Release|iPhone.Build.0 = Release|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7F748FFA-752C-49E7-98F6-C07FCC364D84}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request introduces a new Blazor WebAssembly frontend for HealthNerd, enabling users to export Apple Health data to Excel directly in the browser. It adds a new project with user interface, file handling, settings persistence, and a deployment workflow. The most important changes are grouped below.

### New WASM Frontend Implementation

* Added a new Blazor WebAssembly project (`HealthNerd.Wasm`) with a user interface for uploading Apple Health export ZIP files and optional custom Excel sheets, configuring export settings, and generating downloadable Excel reports. The main UI is implemented in `Home.razor`.
* Created `WebSettings` model to represent user-configurable export options, and a `SettingsMapper` to convert these to the format required by the core Excel report generator. [[1]](diffhunk://#diff-46d0b414273d3f4161bc7a0ebc3420f96fa1f530a395b9f5f330e7868745decbR1-R17) [[2]](diffhunk://#diff-54925b7205c909488a31f77208a801a09b05170687ad51a7852cf447da7fed17R1-R37)
* Implemented `LocalStorageService` for persisting user settings in the browser's local storage, ensuring settings are retained across sessions.

### Build, Styling, and App Initialization

* Added a project file (`HealthNerd.Wasm.csproj`) targeting .NET 8, referencing required NuGet packages for Blazor, HealthKit data parsing, Excel generation, and JSON serialization.
* Included a modern CSS stylesheet for the app's layout and appearance in `app.css`, and set up the main HTML entrypoint in `index.html`. [[1]](diffhunk://#diff-8e361756262e0bee450b95e99b3bdf805e200102301b4325d917921b9e893961R1-R236) [[2]](diffhunk://#diff-0d5ed2430e49255eecd9d840d45efab096a28bf15e3f14b1c29f0898aeab8160R1-R18)
* Configured the Blazor app entrypoint in `Program.cs`, including EPPlus license setup and component registration.

### Routing, Imports, and Workflow

* Added `App.razor` for routing and error handling, and `_Imports.razor` for common using statements across components. [[1]](diffhunk://#diff-3a05e0cfcfce0514146f3fa0338d9642995cc7c9aab1461b7e8be97c672eba3eR1-R8) [[2]](diffhunk://#diff-3f058251735b400d1f330365b34a8d0edf629fdcb6eb6a18879beb9ba4c40972R1-R10)
* Introduced a GitHub Actions workflow (`deploy-wasm.yml`) to automatically build and deploy the WASM app to the `htmltools` repository on pushes to `master`.