### PR TITLE
Fix base href to match actual deployment path /htmltools/healthnerd/

### DIFF
--- a/src/HealthNerd.Wasm/wwwroot/index.html
+++ b/src/HealthNerd.Wasm/wwwroot/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>HealthNerd</title>
-    <base href="/healthnerd/" />
+    <base href="/htmltools/healthnerd/" />
     <link rel="stylesheet" href="css/app.css" />
 </head>
 <body>


### PR DESCRIPTION
The app is served at jonfuller.co/htmltools/healthnerd/ but base href was /healthnerd/, causing all _framework/, CSS, and JS assets to 404.

https://claude.ai/code/session_01GwHuC47PH81Zw3EUfgkrYN